### PR TITLE
Introduce SerializeOctets and DeserializeOctets traits.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ keywords = ["octets", "bytes", "generics"]
 license = "BSD-3-Clause"
 
 [dependencies]
-bytes    = { version = "1.0", optional = true }
-smallvec = { version = "1.0", optional = true }
+bytes    = { version = "1", optional = true }
+serde    = { version = "1", optional = true }
+smallvec = { version = "1", optional = true }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This PR adds two new traits to make it possible to write `serde::Serialize` and `serde::Deserialize` impls for types that are generic over octet sequences.